### PR TITLE
Fix pull request link

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -12,9 +12,9 @@ layout: base
   <h2>How to join</h2>
 
   <ol>
-    <li>Read our <a href="https://github.com/arielsalminen/design-system.club/blob/master/.github/CODE_OF_CONDUCT.md">code of conduct</a>.</li>
+    <li>Read our <a href="{{ meta.repo }}/blob/master/.github/CODE_OF_CONDUCT.md">code of conduct</a>.</li>
     <li>Copy and paste the <a href="#web-component">web component</a> or the <a href="#code-snippet">html code snippet</a> somewhere on your website.</li>
-    <li><a href="{{ meta.repo }}/compare">Open a pull request</a> and supply the name and URL of your website in the <a href="{{ meta.repo }}/blob/master/src/data/members.json">members.json</a> file.</li>
+    <li><a href="{{ meta.repo }}/pulls">Open a pull request</a> and supply the name and URL of your website in the <a href="{{ meta.repo }}/blob/master/src/data/members.json">members.json</a> file.</li>
   </ol>
 
   <h2>This webring accepts</h2>


### PR DESCRIPTION
The pull request link on the website was leading to a comparison view between this repo and the upstream fork, which was a little confusing.

Update the link to point to the pull requests page for this repo.

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-21 at 12 45 05@2x](https://github.com/user-attachments/assets/b0ae3f2f-ab87-4a10-8192-b06ea458a04b) | ![CleanShot 2025-04-21 at 12 45 32@2x](https://github.com/user-attachments/assets/54a86bfa-2f8a-4844-8eaf-f176d1ebd813) | 

Also dedupe the repo link for code of conduct.