### PR TITLE
Add Eric Bailey to the webring

### DIFF
--- a/src/data/members.json
+++ b/src/data/members.json
@@ -26,5 +26,9 @@
   {
     "title": "Kevin Muldoon",
     "url": "https://muldoon.design"
+  },
+  {
+    "title": "Eric Bailey",
+    "url": "https://ericwbailey.website/"
   }
 ]


### PR DESCRIPTION
This PR adds [my site](https://ericwbailey.website/) to the webring, specifically [the webring portion of my colophon page](https://ericwbailey.website/colophon/#webrings). 

Thanks for considering it, and for making this site!