### PR TITLE
Add James Nash's site (https://cirrus.twiddles.com)

### DIFF
--- a/src/data/members.json
+++ b/src/data/members.json
@@ -42,5 +42,9 @@
   {
     "title": "Kev Bonett (basher)",
     "url": "https://basher.biz"
+  },
+  {
+    "title": "James Nash (cirrus)",
+    "url": "https://cirrus.twiddles.com/"
   }
 ]


### PR DESCRIPTION
Hi, I'd love to add my site to the ring.

I've added the webring links to my "Links" page: https://cirrus.twiddles.com/links/, which is reachable in one click from any page via the "Links" link in my main nav.

Admittedly, it's been a while since I blogged about design system stuff (though there are a few posts in my archive), but I intend to write some new posts in the coming months.